### PR TITLE
Add Fotomatic SwiftUI skeleton

### DIFF
--- a/Fotomatic/Package.swift
+++ b/Fotomatic/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Fotomatic",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "Fotomatic", targets: ["Fotomatic"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.6.1")
+    ],
+    targets: [
+        .executableTarget(
+            name: "Fotomatic",
+            dependencies: [
+                .product(name: "SwiftSoup", package: "SwiftSoup")
+            ],
+            path: "Sources/Fotomatic"
+        )
+    ]
+)

--- a/Fotomatic/README.md
+++ b/Fotomatic/README.md
@@ -1,0 +1,17 @@
+# Fotomatic
+
+SwiftUI image search app for macOS. Requires Xcode 15 and macOS 14 or later.
+
+## Building
+
+1. Open Terminal and navigate to this directory:
+   ```bash
+   cd path/to/Fotomatic
+   ```
+2. Resolve Swift package dependencies and build:
+   ```bash
+   swift build -c release
+   ```
+3. To run in Xcode, create a new project from the package or open `Package.swift` directly.
+
+The app fetches images from Google, Yandex and Pinterest simultaneously and displays them in a responsive grid.

--- a/Fotomatic/Sources/Fotomatic/ContentView.swift
+++ b/Fotomatic/Sources/Fotomatic/ContentView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = FotomaticViewModel()
+
+    private let columns = [GridItem(.adaptive(minimum: 200))]
+
+    var body: some View {
+        VStack {
+            Text("Fotomatic")
+                .font(.largeTitle)
+                .padding(.top)
+
+            HStack {
+                TextField("Buscar imagens", text: $viewModel.query)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .onSubmit {
+                        Task { await viewModel.search() }
+                    }
+
+                Button("Buscar") {
+                    Task { await viewModel.search() }
+                }
+                .disabled(viewModel.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding()
+
+            if viewModel.isLoading {
+                ProgressView().padding()
+            }
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 8) {
+                    ForEach(viewModel.images, id: \.self) { url in
+                        AsyncImage(url: url) { phase in
+                            switch phase {
+                            case .empty:
+                                ZStack { Color.gray.opacity(0.3); ProgressView() }
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                            case .failure:
+                                ZStack { Color.gray }
+                            @unknown default:
+                                EmptyView()
+                            }
+                        }
+                        .frame(height: 120)
+                        .clipped()
+                    }
+                }
+                .padding()
+            }
+
+            if let message = viewModel.errorMessage {
+                Text(message)
+                    .foregroundColor(.red)
+                    .padding()
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Fotomatic/Sources/Fotomatic/FotomaticApp.swift
+++ b/Fotomatic/Sources/Fotomatic/FotomaticApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct FotomaticApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Fotomatic/Sources/Fotomatic/FotomaticViewModel.swift
+++ b/Fotomatic/Sources/Fotomatic/FotomaticViewModel.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class FotomaticViewModel: ObservableObject {
+    @Published var query = ""
+    @Published var images: [URL] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let engines: [SearchEngine] = [.google, .yandex, .pinterest]
+
+    func search() async {
+        let term = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !term.isEmpty else { return }
+
+        isLoading = true
+        errorMessage = nil
+        images = []
+
+        await withTaskGroup(of: [URL].self) { group in
+            for engine in engines {
+                group.addTask {
+                    await engine.fetch(term)
+                }
+            }
+
+            var collected = Set<URL>()
+            for await result in group {
+                collected.formUnion(result)
+            }
+            images = Array(collected.prefix(60))
+        }
+
+        isLoading = false
+        if images.isEmpty {
+            errorMessage = "Nenhuma imagem encontrada."
+        }
+    }
+}

--- a/Fotomatic/Sources/Fotomatic/Info.plist
+++ b/Fotomatic/Sources/Fotomatic/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Fotomatic</string>
+    <key>CFBundleName</key>
+    <string>Fotomatic</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/Fotomatic/Sources/Fotomatic/SearchEngine.swift
+++ b/Fotomatic/Sources/Fotomatic/SearchEngine.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftSoup
+
+struct SearchEngine: Identifiable {
+    let id = UUID()
+    let name: String
+    let base: URL
+    let queryParam: String
+
+    func url(for term: String) -> URL? {
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
+        var queryItems = components.queryItems ?? []
+        queryItems.append(URLQueryItem(name: queryParam, value: term))
+        // Google image search requires tbm=isch and tbs=iar:w to get original images
+        if name.lowercased() == "google" {
+            queryItems.append(URLQueryItem(name: "tbm", value: "isch"))
+            queryItems.append(URLQueryItem(name: "tbs", value: "iar:w"))
+        }
+        components.queryItems = queryItems
+        return components.url
+    }
+
+    func fetch(_ term: String) async -> [URL] {
+        guard let url = url(for: term) else { return [] }
+        var request = URLRequest(url: url)
+        request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            guard let html = String(data: data, encoding: .utf8) else { return [] }
+            let doc = try SwiftSoup.parse(html)
+            let images = try doc.select("img").compactMap { try? $0.attr("src") }
+            let urls = images.compactMap(URL.init)
+            let unique = Array(Set(urls)).prefix(30)
+            return Array(unique)
+        } catch {
+            return []
+        }
+    }
+}
+
+extension SearchEngine {
+    static let google = SearchEngine(name: "Google", base: URL(string: "https://www.google.com/search")!, queryParam: "q")
+    static let yandex = SearchEngine(name: "Yandex", base: URL(string: "https://yandex.com/images/search")!, queryParam: "text")
+    static let pinterest = SearchEngine(name: "Pinterest", base: URL(string: "https://www.pinterest.com/search/pins/")!, queryParam: "q")
+}

--- a/Fotomatic/Sources/Fotomatic/TimeFilter.swift
+++ b/Fotomatic/Sources/Fotomatic/TimeFilter.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum TimeFilter: String, CaseIterable, Identifiable {
+    case all       = "All time"
+    case lastHour  = "Last hour"
+    case last24h   = "Last 24h"
+    case lastWeek  = "Last week"
+    case lastMonth = "Last month"
+
+    var id: String { rawValue }
+
+    /// Predefined parameters for Google (`tbs`) and Bing (`qft`)
+    var googleTbs: String? {
+        switch self {
+        case .all:       return nil
+        case .lastHour:  return "qdr:h"
+        case .last24h:   return "qdr:d"
+        case .lastWeek:  return "qdr:w"
+        case .lastMonth: return "qdr:m"
+        }
+    }
+
+    var bingQft: String? {
+        switch self {
+        case .all:       return nil
+        case .lastHour:  return "+filterui:age-lt24hr"
+        case .last24h:   return "+filterui:age-lt24hr"
+        case .lastWeek:  return "+filterui:age-lt7days"
+        case .lastMonth: return "+filterui:age-lt30days"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create Fotomatic SwiftUI macOS app
- implement `TimeFilter` enum
- add `SearchEngine` struct with async scraping
- build `FotomaticViewModel`
- display UI in `ContentView`
- add `FotomaticApp` entry point
- include SwiftPM package with `SwiftSoup` dependency
- provide build instructions in README

## Testing
- `swift build -c release` *(fails: couldn't connect to github for SwiftSoup)*